### PR TITLE
Move solid-state transformer platform to additional projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -856,17 +856,6 @@
 
                 <div class="project-card">
                     <div class="project-icon">
-                        <i class="fas fa-network-wired"></i>
-                    </div>
-                    <h3>Solid-State Transformer Platform</h3>
-                    <p>Advanced SST platform with SiC/GaN devices for EV DCFC, servers/data centers, and national grid integration. 3-stage architecture (NPC→DAB→INV), medium-frequency transformer design, ZVS optimization, and IEEE-1547 grid services.</p>
-                    <a href="sst-platform.html" class="project-link">
-                        <i class="fas fa-external-link-alt"></i> View Project Details
-                    </a>
-                </div>
-
-                <div class="project-card">
-                    <div class="project-icon">
                         <i class="fas fa-ring"></i>
                     </div>
                     <h3>Silicon Photonics - Microring Resonator</h3>


### PR DESCRIPTION
Remove 'Solid-State Transformer Platform' from Featured Projects on the main page to display it only in Additional Projects.

---
<a href="https://cursor.com/background-agent?bcId=bc-bab7d855-518c-4dff-b85d-fc9101981c05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bab7d855-518c-4dff-b85d-fc9101981c05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

